### PR TITLE
Option to treat numbers as object keys rather than arrays when transposing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ That is, where ```obj``` is equivalent to:
 
 	flat = DataObjectParser.untranspose(structured)
 
-	structured = DataObjectParser.transpose(flat)
+	structured = DataObjectParser.transpose(flat, [options] /*default: {transposeNumAsArray : false}*/) 
 
 Where the equivalent results would be:
 

--- a/lib/utils/dataobject-parser.js
+++ b/lib/utils/dataobject-parser.js
@@ -5,8 +5,10 @@
  */
 var _ = require('lodash');
 
-function DataObjectParser($data){
+function DataObjectParser($data, options){
   this._data = $data || {};
+  options = options || {};
+  this._numbersAreArrays = !!options.transposeNumAsArray;
 }
 
 /**
@@ -35,12 +37,20 @@ DataObjectParser.prototype.set = function($path, $value) {
       $obj[$key] = $data;
     }
   };
+  
+  var isTreatLikeArray = function(key) {
+    if(_.isNumber(key)) {
+      return this._numbersAreArrays;
+    }
+    
+    return key === "[]";
+  }
 
   while(pathList.length > 0) {
     parentKey = pathList.shift().replace(/["']/g, '');
 
-    // Number, treat it as an array
-    if (!isNaN(+parentKey) || parentKey === "[]") {
+    // Number, check whether to treat as Array
+    if (isTreatLikeArray(parentKey)) {
       if(!_.isArray(parent)  /* prevent overwritting */ ) {
         parent = [];
         addObj(grandParent, grandParentKey, parent);


### PR DESCRIPTION
We had a use case where we needed numbers in the flattened keys to be structured as string keys in an object rather than being arrays.
